### PR TITLE
Don't report TypeConversionAllocations on static methods in C#11

### DIFF
--- a/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/AllocationAnalyzerTests.cs
@@ -39,7 +39,7 @@ namespace ClrHeapAllocationAnalyzer.Test
 {
     public abstract class AllocationAnalyzerTests
     {
-        protected static readonly List<MetadataReference> references = new List<MetadataReference>
+        protected static readonly List<MetadataReference> References = new List<MetadataReference>
             {
                 MetadataReference.CreateFromFile(typeof(int).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
@@ -80,6 +80,12 @@ namespace ClrHeapAllocationAnalyzer.Test
             Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Latest)
         {
 
+#if NET5_0
+            languageVersion = LanguageVersion.CSharp9;
+#elif NET6_0
+            languageVersion = LanguageVersion.CSharp10;
+#endif
+
             var options = new CSharpParseOptions(kind: SourceCodeKind.Script, languageVersion: languageVersion);
             var tree = CSharpSyntaxTree.ParseText(sampleProgram, options, filePath);
 
@@ -87,9 +93,9 @@ namespace ClrHeapAllocationAnalyzer.Test
             Assembly.GetEntryAssembly()
                     .GetReferencedAssemblies()
                     .ToList()
-                    .ForEach(a => references.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
+                    .ForEach(a => References.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
 
-            var compilation = CSharpCompilation.Create("Test", new[] { tree }, references);
+            var compilation = CSharpCompilation.Create("Test", new[] { tree }, References);
 
             var diagnostics = compilation.GetDiagnostics();
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))

--- a/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
+++ b/ClrHeapAllocationsAnalyzer.Test/ClrHeapAllocationsAnalyzer.Test.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>net5.0;net7.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<IsPackable>false</IsPackable>
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 
 

--- a/ClrHeapAllocationsAnalyzer.Test/DiagnosticEqualityComparer.cs
+++ b/ClrHeapAllocationsAnalyzer.Test/DiagnosticEqualityComparer.cs
@@ -25,12 +25,7 @@ namespace ClrHeapAllocationAnalyzer.Test
         {
             int hash = unchecked(currentKey.Value * (int)0xA5555529);
 
-            if (newKeyPart.HasValue)
-            {
-                return unchecked(hash + newKeyPart.Value);
-            }
-
-            return hash;
+            return newKeyPart.HasValue ? hash + newKeyPart.Value : hash;
         }
     }
 }

--- a/ClrHeapAllocationsAnalyzer.Vsix/source.extension.vsixmanifest
+++ b/ClrHeapAllocationsAnalyzer.Vsix/source.extension.vsixmanifest
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ClrHeapAllocationAnalyzer..f21077b6-a9d3-4fb6-81a3-b46dfd105fd4" Version="2.0" Language="en-US" Publisher="MJSABBY"/>
-        <DisplayName>Clr Heap Allocation Analyzer</DisplayName>
+        <Identity Id="ClrHeapAllocationAnalyzer.924F5A34-4DD8-419E-A648-EBE86D26A17A" Version="2.0" Language="en-US" Publisher="Fons Sonnemans"/>
+        <DisplayName>ClrHeapAllocationAnalyzer</DisplayName>
         <Description xml:space="preserve">Clr Heap Allocation Analyzer is a Roslyn based Diagnostic Analyzer that is able to detect most allocations in code in the local method and bring them to your attention in Visual Studio. It can detect subtle allocations caused by value type boxing, closure captures, delegate instantiations, etc.</Description>
-        <MoreInfo>https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer</MoreInfo>
+        <MoreInfo>https://github.com/sonnemaf/RoslynClrHeapAllocationAnalyzer</MoreInfo>
         <License>LICENSE.txt</License>
         <Tags>roslyn clr allocations boxing closure display performance</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">

--- a/ClrHeapAllocationsAnalyzer/AllocationRules.cs
+++ b/ClrHeapAllocationsAnalyzer/AllocationRules.cs
@@ -6,7 +6,7 @@ namespace ClrHeapAllocationAnalyzer
 {
     public class AllocationRules
     {
-        private static readonly HashSet<ValueTuple<string, string>> IgnoredAttributes = new HashSet<(string, string)>
+        private static HashSet<ValueTuple<string, string>> IgnoredAttributes { get; } = new HashSet<(string, string)>
         {
             ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"),
             ("System.CodeDom.Compiler", "GeneratedCodeAttribute")

--- a/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/CallSiteImplicitAllocationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace ClrHeapAllocationAnalyzer
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CallSiteImplicitAllocationAnalyzer : AllocationAnalyzer
     {
-        public static DiagnosticDescriptor ParamsParameterRule = new DiagnosticDescriptor("HAA0101", "Array allocation for params parameter", "This call site is calling into a function with a 'params' parameter. This results in an array allocation", "Performance", DiagnosticSeverity.Warning, true);
+        public static DiagnosticDescriptor ParamsParameterRule = new DiagnosticDescriptor("HAA0101", "Array allocation for params parameter", "This call site is calling into a function with a 'params' parameter. This results in an array allocation.", "Performance", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor ValueTypeNonOverridenCallRule = new DiagnosticDescriptor("HAA0102", "Non-overridden virtual method call on value type", "Non-overridden virtual method call on a value type adds a boxing or constrained instruction", "Performance", DiagnosticSeverity.Warning, true);
 
@@ -18,7 +18,7 @@ namespace ClrHeapAllocationAnalyzer
 
         protected override SyntaxKind[] Expressions => new[] { SyntaxKind.InvocationExpression };
 
-        private static readonly object[] EmptyMessageArgs = { };
+        private static object[] EmptyMessageArgs { get; } = { };
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {

--- a/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
+++ b/ClrHeapAllocationsAnalyzer/ClrHeapAllocationAnalyzer.csproj
@@ -3,9 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
-		<Version>3.1.0</Version>
+		<Version>3.2.0</Version>
 		<PackageId>*$(MSBuildProjectFile)*</PackageId>
 		<AssemblyName>ReflectionIT.ClrHeapAllocationAnalyzer</AssemblyName>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 	</PropertyGroup>
 
 

--- a/ClrHeapAllocationsAnalyzer/CompilationExtensions.cs
+++ b/ClrHeapAllocationsAnalyzer/CompilationExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+
+namespace ClrHeapAllocationAnalyzer {
+    /// <summary>
+    /// Extension methods for the <see cref="Compilation"/> type.
+    /// </summary>
+    internal static class CompilationExtensions {
+        /// <summary>
+        /// Checks whether a given compilation (assumed to be for C#) is using at least a given language version.
+        /// </summary>
+        /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+        /// <param name="languageVersion">The minimum language version to check.</param>
+        /// <returns>Whether <paramref name="compilation"/> is using at least the specified language version.</returns>
+        public static bool HasLanguageVersionAtLeastEqualTo(this Compilation compilation, LanguageVersion languageVersion) {
+            return ((CSharpCompilation)compilation).LanguageVersion >= languageVersion;
+        }
+    }
+}

--- a/ClrHeapAllocationsAnalyzer/ConcatenationAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/ConcatenationAllocationAnalyzer.cs
@@ -13,13 +13,13 @@
     {
         public static DiagnosticDescriptor StringConcatenationAllocationRule = new DiagnosticDescriptor("HAA0201", "Implicit string concatenation allocation", "Considering using StringBuilder", "Performance", DiagnosticSeverity.Warning, true, string.Empty, "http://msdn.microsoft.com/en-us/library/2839d5h5(v=vs.110).aspx");
 
-        public static DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new DiagnosticDescriptor("HAA0202", "Value type to reference type conversion allocation for string concatenation", "Value type ({0}) is being boxed to a reference type for a string concatenation.", "Performance", DiagnosticSeverity.Warning, true, string.Empty, "http://msdn.microsoft.com/en-us/library/yz2be5wk.aspx");
+        public static DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new DiagnosticDescriptor("HAA0202", "Value type to reference type conversion allocation for string concatenation", "Value type ({0}) is being boxed to a reference type for a string concatenation", "Performance", DiagnosticSeverity.Warning, true, string.Empty, "http://msdn.microsoft.com/en-us/library/yz2be5wk.aspx");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(StringConcatenationAllocationRule, ValueTypeToReferenceTypeInAStringConcatenationRule);
 
         protected override SyntaxKind[] Expressions => new[] { SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression };
 
-        private static readonly object[] EmptyMessageArgs = { };
+        private static object[] EmptyMessageArgs { get; } = { };
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {

--- a/ClrHeapAllocationsAnalyzer/DisplayClassAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/DisplayClassAllocationAnalyzer.cs
@@ -22,7 +22,7 @@
 
         protected override SyntaxKind[] Expressions => new[] { SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.AnonymousMethodExpression };
 
-        private static readonly object[] EmptyMessageArgs = { };
+        private static object[] EmptyMessageArgs { get; } = { };
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {

--- a/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/EnumeratorAllocationAnalyzer.cs
@@ -17,7 +17,7 @@
 
         protected override SyntaxKind[] Expressions => new[] { SyntaxKind.ForEachStatement, SyntaxKind.InvocationExpression };
 
-        private static readonly object[] EmptyMessageArgs = { };
+        private static object[] EmptyMessageArgs { get; } = { };
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {

--- a/ClrHeapAllocationsAnalyzer/ExplicitAllocationAnalyzer.cs
+++ b/ClrHeapAllocationsAnalyzer/ExplicitAllocationAnalyzer.cs
@@ -37,7 +37,7 @@
             SyntaxKind.LetClause                            // Used
         };
 
-        private static readonly object[] EmptyMessageArgs = { };
+        private static object[] EmptyMessageArgs { get; } = { };
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {

--- a/ClrHeapAllocationsAnalyzer/SyntaxHelper.cs
+++ b/ClrHeapAllocationsAnalyzer/SyntaxHelper.cs
@@ -6,12 +6,7 @@ namespace ClrHeapAllocationAnalyzer
     {
         public static T FindContainer<T>(this SyntaxNode tokenParent) where T : SyntaxNode
         {
-            if (tokenParent is T invocation)
-            {
-                return invocation;
-            }
-
-            return tokenParent.Parent == null ? null : FindContainer<T>(tokenParent.Parent);
+            return tokenParent is T invocation ? invocation : tokenParent.Parent == null ? null : FindContainer<T>(tokenParent.Parent);
         }
     }
 }


### PR DESCRIPTION
Ready to publish to NuGet and Marketplace